### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Django==3.1.7
+Django>=3.1.7, <=4.0.2
 django-debug-toolbar==3.2
-django-phonenumber-field==5.0.0
+django-phonenumber-field>=5.0.0,<=4.1.0
 phonenumbers==8.12.20
 tox==3.23.0


### PR DESCRIPTION
ugettext_lazy depricated  in Django 3+ and used by django-phonenumber-field 5.0.0. Install the latest